### PR TITLE
6009 Remove ProjectStepModalView from LoanTabView.

### DIFF
--- a/app/assets/javascripts/backbone/views/loan_tab_view.coffee
+++ b/app/assets/javascripts/backbone/views/loan_tab_view.coffee
@@ -7,9 +7,6 @@ class MS.Views.LoanTabView extends Backbone.View
     @calendarEventsUrl = params.calendarEventsUrl
     @locale = params.locale
 
-    # This is shared among several tabs so we initialize it here.
-    @stepModal = new MS.Views.ProjectStepModalView()
-
   events:
     'shown.ms.tab': 'tabShown'
 


### PR DESCRIPTION
It is no longer needed because of the tab refactor.