### PR TITLE
6017 display media type on media attachment

### DIFF
--- a/app/assets/stylesheets/admin/media/_media.scss
+++ b/app/assets/stylesheets/admin/media/_media.scss
@@ -1,7 +1,14 @@
 @import '../colors';
 
+$media-block-width: 100px;
+
 .media-browser {
-  div.media-item { display: inline-block; }
+  div.media-item {
+    display: inline-block;
+    text-align: center;
+    height: auto;
+    vertical-align: top;
+  }
 
   .thumb {
     position: relative;
@@ -28,20 +35,29 @@
       }
     }
 
-    .extension {
-      background-color: $gray2;
+    .extension, .media-block {
       display: block;
-      width: 100px;
-      height: 100px;
+      width: $media-block-width;
+      height: $media-block-width;
       padding-top: 32px;
-      text-align: center;
+      background-color: $gray2;
       color: $gray3;
+    }
+
+    .extension {
       font-size: 1.4em;
+    }
+
+    .media-title {
+      width: $media-block-width;
     }
 
     a {
       display: block;
-      &:hover { text-decoration: none; }
+
+      &:hover {
+        text-decoration: none;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/admin/media/_media.scss
+++ b/app/assets/stylesheets/admin/media/_media.scss
@@ -48,6 +48,12 @@ $media-block-width: 100px;
       font-size: 1.4em;
     }
 
+    .media-block {
+      i {
+        font-size: 1.4em;
+      }
+    }
+
     .media-title {
       width: $media-block-width;
     }

--- a/app/assets/stylesheets/admin/media/_media.scss
+++ b/app/assets/stylesheets/admin/media/_media.scss
@@ -56,6 +56,7 @@ $media-block-width: 100px;
 
     .media-title {
       width: $media-block-width;
+      color: $gray3;
     }
 
     a {

--- a/app/assets/stylesheets/admin/media/_media.scss
+++ b/app/assets/stylesheets/admin/media/_media.scss
@@ -5,21 +5,21 @@ $media-block-width: 100px;
 .media-browser {
   div.media-item {
     display: inline-block;
-    text-align: center;
     height: auto;
     vertical-align: top;
+    text-align: center;
   }
 
   .thumb {
-    position: relative;
     margin-bottom: 15px;
     margin-right: 15px;
+    position: relative;
 
     .actions {
+      display: none;
       position: absolute;
       top: 0px;
       right: 2px;
-      display: none;
       font-size: 18px;
 
       a {

--- a/app/assets/stylesheets/admin/media/_media.scss
+++ b/app/assets/stylesheets/admin/media/_media.scss
@@ -57,6 +57,7 @@ $media-block-width: 100px;
     .media-title {
       width: $media-block-width;
       color: $gray3;
+      cursor: pointer;
     }
 
     a {

--- a/app/assets/stylesheets/admin/media/_media.scss
+++ b/app/assets/stylesheets/admin/media/_media.scss
@@ -3,6 +3,10 @@
 $media-block-width: 100px;
 
 .media-browser {
+  h4 {
+    font-size: 15px;
+  }
+
   div.media-item {
     display: inline-block;
     height: auto;

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -72,4 +72,9 @@ module AdminHelper
     # Subtract 1 from depth since root node either doesn't display or displays as "[None]"
     ("&nbsp; &nbsp; " * [node.depth - 1, 0].max).html_safe << node.send(label_method)
   end
+
+  # Displays Font Awesome icons
+  def icon_tag(class_name)
+    content_tag(:i, "", class: "fa fa-#{class_name}")
+  end
 end

--- a/app/helpers/media_helper.rb
+++ b/app/helpers/media_helper.rb
@@ -40,4 +40,12 @@ module MediaHelper
       end
     end
   end
+
+  def media_visuals(media)
+    media.select do |media_item| media_item.visual? end
+  end
+
+  def media_documents(media)
+    media.select do |media_item| !media_item.visual? end
+  end
 end

--- a/app/helpers/media_helper.rb
+++ b/app/helpers/media_helper.rb
@@ -3,17 +3,21 @@ module MediaHelper
     if media_item.thumbnail?
       image_tag(media_item.item.thumb.url)
     else
-      media_extension = File.extname(media_item.item.file.path).downcase
-      # content_tag(:div, class: "generic-thumbnail") do
-        content_tag(:div, media_extension, class: "extension")
-        # concat(image_tag("file-blank.png"))
-      # end
+      # media_extension = File.extname(media_item.item.file.path).downcase
+      # # content_tag(:div, class: "generic-thumbnail") do
+      # content_tag(:div, media_extension, class: "extension")
+      # # concat(image_tag("file-blank.png"))
+      # # end
+      content_tag(:div, media_item.kind_value.capitalize, class: "media-block")
     end
   end
 
   def media_title(media_item)
     ext = File.extname(media_item.item.file.path)
     file_name = truncate(File.basename(media_item.item.file.path, ext), length: 15)
-    content_tag(:span, "#{file_name}#{ext.downcase}")
+    content_tag(:div, class: "media-title") do
+      concat(content_tag(:span, file_name))
+      concat(content_tag(:div, ext.downcase))
+    end
   end
 end

--- a/app/helpers/media_helper.rb
+++ b/app/helpers/media_helper.rb
@@ -22,7 +22,7 @@ module MediaHelper
   end
 
   def media_icon_class(media_item)
-    if media_item.visual_media?
+    if media_item.visual?
       if media_item.kind_value == "video"
         "file-video-o"
       else

--- a/app/helpers/media_helper.rb
+++ b/app/helpers/media_helper.rb
@@ -5,8 +5,7 @@ module MediaHelper
     else
       content_tag(:div, class: "media-block") do
         concat(content_tag(:div, media_item.kind_value.capitalize))
-        concat(sanitize("<i class='fa fa-#{media_icon_class(media_item)}'></i>", tags: %w(i),
-          attributes: %w(class)))
+        concat(icon(media_icon_class(media_item)))
       end
     end
   end

--- a/app/helpers/media_helper.rb
+++ b/app/helpers/media_helper.rb
@@ -22,7 +22,7 @@ module MediaHelper
 
   def media_icon_class(media_item)
     if media_item.visual_media?
-      if media_item.kind_value.downcase == "video"
+      if media_item.kind_value == "video"
         "file-video-o"
       else
         "file-image-o"

--- a/app/helpers/media_helper.rb
+++ b/app/helpers/media_helper.rb
@@ -14,7 +14,8 @@ module MediaHelper
   def media_title(media_item)
     ext = File.extname(media_item.item.file.path)
     file_name = truncate(File.basename(media_item.item.file.path, ext), length: 12)
-    content_tag(:div, class: "media-title") do
+    full_name = File.basename(media_item.item.file.path)
+    content_tag(:div, class: "media-title", title: "#{full_name}") do
       concat(content_tag(:span, file_name))
       concat(content_tag(:div, ext.downcase))
     end

--- a/app/helpers/media_helper.rb
+++ b/app/helpers/media_helper.rb
@@ -3,11 +3,6 @@ module MediaHelper
     if media_item.thumbnail?
       image_tag(media_item.item.thumb.url)
     else
-      # media_extension = File.extname(media_item.item.file.path).downcase
-      # # content_tag(:div, class: "generic-thumbnail") do
-      # content_tag(:div, media_extension, class: "extension")
-      # # concat(image_tag("file-blank.png"))
-      # # end
       content_tag(:div, class: "media-block") do
         concat(content_tag(:div, media_item.kind_value.capitalize))
         concat(sanitize("<i class='fa fa-#{media_icon_class(media_item)}'></i>", tags: %w(i),

--- a/app/helpers/media_helper.rb
+++ b/app/helpers/media_helper.rb
@@ -14,7 +14,7 @@ module MediaHelper
     ext = File.extname(media_item.item.file.path)
     file_name = truncate(File.basename(media_item.item.file.path, ext), length: 12)
     full_name = File.basename(media_item.item.file.path)
-    content_tag(:div, class: "media-title", title: "#{full_name}") do
+    content_tag(:div, class: "media-title", title: full_name) do
       concat(content_tag(:span, file_name))
       concat(content_tag(:div, ext.downcase))
     end
@@ -30,15 +30,14 @@ module MediaHelper
     else
       case ext = File.extname(media_item.item.file.path)
       when ".pdf"
-        icon_class = "file-pdf-o"
+        "file-pdf-o"
       when ".doc"
-        icon_class = "file-word-o"
+        "file-word-o"
       when ".docx"
-        icon_class = "file-word-o"
+        "file-word-o"
       else
-        icon_class = "file-text-o"
+        "file-text-o"
       end
-      return icon_class
     end
   end
 end

--- a/app/helpers/media_helper.rb
+++ b/app/helpers/media_helper.rb
@@ -8,7 +8,11 @@ module MediaHelper
       # content_tag(:div, media_extension, class: "extension")
       # # concat(image_tag("file-blank.png"))
       # # end
-      content_tag(:div, media_item.kind_value.capitalize, class: "media-block")
+      content_tag(:div, class: "media-block") do
+        concat(content_tag(:div, media_item.kind_value.capitalize))
+        concat(sanitize("<i class='fa fa-#{media_icon_class(media_item)}'></i>", tags: %w(i),
+          attributes: %w(class)))
+      end
     end
   end
 
@@ -18,6 +22,28 @@ module MediaHelper
     content_tag(:div, class: "media-title") do
       concat(content_tag(:span, file_name))
       concat(content_tag(:div, ext.downcase))
+    end
+  end
+
+  def media_icon_class(media_item)
+    if media_item.visual_media?
+      if media_item.kind_value.downcase == "video"
+        "file-video-o"
+      else
+        "file-image-o"
+      end
+    else
+      case ext = File.extname(media_item.item.file.path)
+      when ".pdf"
+        icon_class = "file-pdf-o"
+      when ".doc"
+        icon_class = "file-word-o"
+      when ".docx"
+        icon_class = "file-word-o"
+      else
+        icon_class = "file-text-o"
+      end
+      return icon_class
     end
   end
 end

--- a/app/helpers/media_helper.rb
+++ b/app/helpers/media_helper.rb
@@ -10,4 +10,10 @@ module MediaHelper
       # end
     end
   end
+
+  def media_title(media_item)
+    ext = File.extname(media_item.item.file.path)
+    file_name = File.basename(media_item.item.file.path, ext)
+    content_tag(:span, "#{file_name}#{ext.downcase}")
+  end
 end

--- a/app/helpers/media_helper.rb
+++ b/app/helpers/media_helper.rb
@@ -14,7 +14,7 @@ module MediaHelper
 
   def media_title(media_item)
     ext = File.extname(media_item.item.file.path)
-    file_name = truncate(File.basename(media_item.item.file.path, ext), length: 15)
+    file_name = truncate(File.basename(media_item.item.file.path, ext), length: 12)
     content_tag(:div, class: "media-title") do
       concat(content_tag(:span, file_name))
       concat(content_tag(:div, ext.downcase))

--- a/app/helpers/media_helper.rb
+++ b/app/helpers/media_helper.rb
@@ -13,7 +13,7 @@ module MediaHelper
 
   def media_title(media_item)
     ext = File.extname(media_item.item.file.path)
-    file_name = File.basename(media_item.item.file.path, ext)
+    file_name = truncate(File.basename(media_item.item.file.path, ext), length: 15)
     content_tag(:span, "#{file_name}#{ext.downcase}")
   end
 end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -58,4 +58,14 @@ class Media < ActiveRecord::Base
     # Only submit a job if it is a Loan
     RecalculateLoanHealthJob.perform_later(loan_id: media_attachable_id) if media_attachable_type == 'Project'
   end
+
+  def visual_media?
+    if kind_value == "image"
+      true
+    elsif kind_value == "video"
+      true
+    else
+      false
+    end
+  end
 end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -51,7 +51,7 @@ class Media < ActiveRecord::Base
   end
 
   def thumbnail?
-    kind_value == 'image' ? (item_content_type.include? "image") : false
+    kind_value == "image" && item_content_type.include?("image")
   end
 
   def recalculate_loan_health

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -51,7 +51,7 @@ class Media < ActiveRecord::Base
   end
 
   def thumbnail?
-    kind_value == 'image'
+    kind_value == 'image' ? (item_content_type.include? "image") : false
   end
 
   def recalculate_loan_health

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -59,13 +59,7 @@ class Media < ActiveRecord::Base
     RecalculateLoanHealthJob.perform_later(loan_id: media_attachable_id) if media_attachable_type == 'Project'
   end
 
-  def visual_media?
-    if kind_value == "image"
-      true
-    elsif kind_value == "video"
-      true
-    else
-      false
-    end
+  def visual?
+    %w(image video).include?(kind_value)
   end
 end

--- a/app/views/admin/media/_index.html.slim
+++ b/app/views/admin/media/_index.html.slim
@@ -1,6 +1,6 @@
 - link_params = {attachable_type: owner.class.model_name.route_key, attachable_id: owner.id}
-- visuals = media_visuals(media)
-- documents = media_documents(media)
+- visuals = media_visuals(owner.media)
+- documents = media_documents(owner.media)
 
 .media-browser.col-lg-12 data-media-type="#{owner.class.name}"
   h3 = t("media.media")

--- a/app/views/admin/media/_index.html.slim
+++ b/app/views/admin/media/_index.html.slim
@@ -3,8 +3,6 @@
 - documents = media_documents(owner.media)
 
 .media-browser.col-lg-12 data-media-type="#{owner.class.name}"
-  h3 = t("media.media")
-
   - if documents.any?
     div
       h4 = t("media.documents")

--- a/app/views/admin/media/_index.html.slim
+++ b/app/views/admin/media/_index.html.slim
@@ -2,22 +2,7 @@
 
 .media-browser.col-lg-12 data-media-type="#{owner.class.name}"
   - owner.media.each do |media_item|
-    div.media-item data-media-id="#{media_item.id}"
-      .thumb
-        = link_to media_thumbnail(media_item), media_item.item.url
-        = media_title(media_item)
-        .actions
-          = link_to edit_admin_media_path(media_item, link_params), class: 'media-action edit' do
-            i.fa.fa-pencil
-          = link_to admin_media_path(media_item, link_params), class: 'media-action delete',
-            data: { \
-              confirm: t('media.confirm_deletion'),
-              'confirm-title': t('media.delete'),
-              'confirm-cancel': t(:cancel),
-              'confirm-proceed': t(:confirm),
-              'confirm-cancel-class': 'media-action btn cancel btn-default',
-              'confirm-proceed-class': 'media-action btn proceed btn-primary' } do
-            i.fa.fa-trash
+    = render "admin/media/media_item", media_item: media_item, link_params: link_params
   div.media-item#media-new
     .thumb
       = link_to image_tag("new-image.png"), new_admin_media_path(link_params),

--- a/app/views/admin/media/_index.html.slim
+++ b/app/views/admin/media/_index.html.slim
@@ -7,13 +7,13 @@
     h4 = t("media.documents")
 
     - owner.media.each do |media_item|
-      - unless media_item.visual_media?
+      - unless media_item.visual?
         = render "admin/media/media_item", media_item: media_item, link_params: link_params
   div
     h4 = t("media.visual_media")
 
     - owner.media.each do |media_item|
-      - if media_item.visual_media?
+      - if media_item.visual?
         = render "admin/media/media_item", media_item: media_item, link_params: link_params
 
   div.media-item#media-new

--- a/app/views/admin/media/_index.html.slim
+++ b/app/views/admin/media/_index.html.slim
@@ -1,16 +1,16 @@
 - link_params = {attachable_type: owner.class.model_name.route_key, attachable_id: owner.id}
 
 .media-browser.col-lg-12 data-media-type="#{owner.class.name}"
-  h3 Media
+  h3 = t("media.media")
 
   div
-    h4 Documents
+    h4 = t("media.documents")
 
     - owner.media.each do |media_item|
       - unless media_item.visual_media?
         = render "admin/media/media_item", media_item: media_item, link_params: link_params
   div
-    h4 Visual media
+    h4 = t("media.visual_media")
 
     - owner.media.each do |media_item|
       - if media_item.visual_media?

--- a/app/views/admin/media/_index.html.slim
+++ b/app/views/admin/media/_index.html.slim
@@ -1,8 +1,21 @@
 - link_params = {attachable_type: owner.class.model_name.route_key, attachable_id: owner.id}
 
 .media-browser.col-lg-12 data-media-type="#{owner.class.name}"
-  - owner.media.each do |media_item|
-    = render "admin/media/media_item", media_item: media_item, link_params: link_params
+  h3 Media
+
+  div
+    h4 Documents
+
+    - owner.media.each do |media_item|
+      - unless media_item.visual_media?
+        = render "admin/media/media_item", media_item: media_item, link_params: link_params
+  div
+    h4 Visual media
+
+    - owner.media.each do |media_item|
+      - if media_item.visual_media?
+        = render "admin/media/media_item", media_item: media_item, link_params: link_params
+
   div.media-item#media-new
     .thumb
       = link_to image_tag("new-image.png"), new_admin_media_path(link_params),

--- a/app/views/admin/media/_index.html.slim
+++ b/app/views/admin/media/_index.html.slim
@@ -5,6 +5,7 @@
     div.media-item data-media-id="#{media_item.id}"
       .thumb
         = link_to media_thumbnail(media_item), media_item.item.url
+        = media_title(media_item)
         .actions
           = link_to edit_admin_media_path(media_item, link_params), class: 'media-action edit' do
             i.fa.fa-pencil

--- a/app/views/admin/media/_index.html.slim
+++ b/app/views/admin/media/_index.html.slim
@@ -1,19 +1,22 @@
 - link_params = {attachable_type: owner.class.model_name.route_key, attachable_id: owner.id}
+- visuals = media_visuals(media)
+- documents = media_documents(media)
 
 .media-browser.col-lg-12 data-media-type="#{owner.class.name}"
   h3 = t("media.media")
 
-  div
-    h4 = t("media.documents")
+  - if documents.any?
+    div
+      h4 = t("media.documents")
 
-    - owner.media.each do |media_item|
-      - unless media_item.visual?
+      - documents.each do |media_item|
         = render "admin/media/media_item", media_item: media_item, link_params: link_params
-  div
-    h4 = t("media.visual_media")
 
-    - owner.media.each do |media_item|
-      - if media_item.visual?
+  - if visuals.any?
+    div
+      h4 = t("media.visual_media")
+
+      - visuals.each do |media_item|
         = render "admin/media/media_item", media_item: media_item, link_params: link_params
 
   div.media-item#media-new

--- a/app/views/admin/media/_media_item.html.slim
+++ b/app/views/admin/media/_media_item.html.slim
@@ -2,6 +2,7 @@ div.media-item data-media-id="#{media_item.id}"
   .thumb
     = link_to media_thumbnail(media_item), media_item.item.url
     = media_title(media_item)
+    = media_icon_class(media_item)
     .actions
       = link_to edit_admin_media_path(media_item, link_params), class: 'media-action edit' do
         i.fa.fa-pencil

--- a/app/views/admin/media/_media_item.html.slim
+++ b/app/views/admin/media/_media_item.html.slim
@@ -1,0 +1,16 @@
+div.media-item data-media-id="#{media_item.id}"
+  .thumb
+    = link_to media_thumbnail(media_item), media_item.item.url
+    = media_title(media_item)
+    .actions
+      = link_to edit_admin_media_path(media_item, link_params), class: 'media-action edit' do
+        i.fa.fa-pencil
+      = link_to admin_media_path(media_item, link_params), class: 'media-action delete',
+        data: { \
+          confirm: t('media.confirm_deletion'),
+          'confirm-title': t('media.delete'),
+          'confirm-cancel': t(:cancel),
+          'confirm-proceed': t(:confirm),
+          'confirm-cancel-class': 'media-action btn cancel btn-default',
+          'confirm-proceed-class': 'media-action btn proceed btn-primary' } do
+        i.fa.fa-trash

--- a/app/views/admin/media/_media_item.html.slim
+++ b/app/views/admin/media/_media_item.html.slim
@@ -2,7 +2,6 @@ div.media-item data-media-id="#{media_item.id}"
   .thumb
     = link_to media_thumbnail(media_item), media_item.item.url
     = media_title(media_item)
-    = media_icon_class(media_item)
     .actions
       = link_to edit_admin_media_path(media_item, link_params), class: 'media-action edit' do
         i.fa.fa-pencil

--- a/app/views/admin/project_logs/index.html.slim
+++ b/app/views/admin/project_logs/index.html.slim
@@ -6,6 +6,7 @@ section.log-list
   = render "admin/project_logs/log_list"
 
 div#log-form-modal
+= render "admin/media/modal"
 
 javascript:
   $(function() {

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -275,7 +275,6 @@ en:
   locked: "Locked"
   login: "Login"
   logout: "Logout"
-  media: "Media"
   more: "More"
   name: "Name"
   none: "None"
@@ -386,10 +385,13 @@ en:
   media:
     confirm_deletion: "Are you sure you want to delete this media item?"
     caption: "%{locale_name} Caption"
+    documents: "Documents"
     add: "Add Media"
     edit: "Edit Media"
     delete: "Delete Media"
     item: "Item"
+    media: "Media"
+    visual_media: "Visual Media"
 
   menu:
     basic_projects: "Projects"


### PR DESCRIPTION
- Rearrange what is displayed for media information
- Display content type on media item
- Add icons to non-image files
- On hover of shortened filename, show full filename
- If no media items present in a section, do not display the section