### PR TITLE
6018: Save the state of the questionnaire tree

### DIFF
--- a/app/assets/javascripts/backbone/views/loan_questionnaires_view.coffee
+++ b/app/assets/javascripts/backbone/views/loan_questionnaires_view.coffee
@@ -32,6 +32,7 @@ class MS.Views.LoanQuestionnairesView extends Backbone.View
     # Initialize the jqtree
     @tree.tree
       dragAndDrop: false
+      saveState: true
       selectable: false
       useContextMenu: false
       # This is fired for each li element in the jqtree just after it's created.


### PR DESCRIPTION
- Allows nodes to remain open on page reload
- When questionnaire is saved, open nodes are remembered