### PR TITLE
6219: Do not close the log modal when clicking outside it

### DIFF
--- a/app/views/admin/project_logs/modal.html.slim
+++ b/app/views/admin/project_logs/modal.html.slim
@@ -1,4 +1,4 @@
-div.modal.fade tabindex="-1" role="dialog" aria-labelledby=""
+div.modal.fade tabindex="-1" role="dialog" aria-labelledby="" data-backdrop="static"
   div.modal-dialog.modal-lg
     div.modal-content
       = render "admin/project_logs/modal_content"


### PR DESCRIPTION
- Add attribute for modal background to not close the modal
- Ensures data is not lost from the log modal when editing