### PR TITLE
6234 media in show log

### DIFF
--- a/app/assets/stylesheets/admin/media/_media.scss
+++ b/app/assets/stylesheets/admin/media/_media.scss
@@ -3,6 +3,10 @@
 $media-block-width: 100px;
 
 .media-browser {
+  .section {
+    display: inline-block;
+  }
+
   h4 {
     font-size: 15px;
   }

--- a/app/models/project_log.rb
+++ b/app/models/project_log.rb
@@ -91,6 +91,6 @@ class ProjectLog < ActiveRecord::Base
   end
 
   def has_more?
-    [details, additional_notes, private_notes].any?(&:present?)
+    [details, additional_notes, private_notes, media].any?(&:present?)
   end
 end

--- a/app/views/admin/media/_index.html.slim
+++ b/app/views/admin/media/_index.html.slim
@@ -4,20 +4,21 @@
 
 .media-browser.col-lg-12 data-media-type="#{owner.class.name}"
   - if documents.any?
-    div
+    .section
       h4 = t("media.documents")
 
       - documents.each do |media_item|
         = render "admin/media/media_item", media_item: media_item, link_params: link_params
 
   - if visuals.any?
-    div
+    .section
       h4 = t("media.visual_media")
 
       - visuals.each do |media_item|
         = render "admin/media/media_item", media_item: media_item, link_params: link_params
 
-  div.media-item#media-new
+  .section.media-item#media-new
+    h4.invisible = t("media.add")
     .thumb
       = link_to image_tag("new-image.png"), new_admin_media_path(link_params),
-        class: 'media-action new'
+        class: 'media-action new', title: t("media.add")

--- a/app/views/admin/project_logs/_log_list.html.slim
+++ b/app/views/admin/project_logs/_log_list.html.slim
@@ -85,6 +85,6 @@
               .extra
                 = simple_format content_tag(:strong, t('log.private_notes')) << log.private_notes.to_s
 
-            .media-container.row
-              - unless log.new_record?
+            - if log.media.present?
+              .extra.media-container.row
                 = render 'admin/media/index', media: log.media, owner: log

--- a/app/views/admin/project_logs/_log_list.html.slim
+++ b/app/views/admin/project_logs/_log_list.html.slim
@@ -84,3 +84,7 @@
             - if log.private_notes.present?
               .extra
                 = simple_format content_tag(:strong, t('log.private_notes')) << log.private_notes.to_s
+
+            .media-container.row
+              - unless log.new_record?
+                = render 'admin/media/index', media: log.media, owner: log


### PR DESCRIPTION
- Show media in show log
- Inside log list, display media
- Display media inside the expand/hide section of the log
- UI changes to media including displaying items inline with each other