### PR TITLE
6191 bug error on batch finalize steps

### DIFF
--- a/app/controllers/admin/project_steps_controller.rb
+++ b/app/controllers/admin/project_steps_controller.rb
@@ -4,9 +4,13 @@ class Admin::ProjectStepsController < Admin::AdminController
 
   def new
     @project = Project.find(params[:project_id])
-    @step = ProjectStep.new(project: @project, scheduled_start_date: params[:date],
-      parent_id: params[:parent_id], schedule_parent_id: params[:schedule_parent_id],
-      step_type_value: 'checkin')
+    @step = ProjectStep.new(
+      project: @project,
+      scheduled_start_date: params[:date],
+      parent_id: params[:parent_id],
+      schedule_parent_id: params[:schedule_parent_id],
+      step_type_value: 'checkin'
+    )
     authorize @step
     if params[:context] == 'timeline_table'
       render_modal_content

--- a/app/models/project_group.rb
+++ b/app/models/project_group.rb
@@ -16,7 +16,7 @@
 #  schedule_parent_id      :integer
 #  scheduled_duration_days :integer          default(0)
 #  scheduled_start_date    :date
-#  step_type_value         :string
+#  step_type_value         :string           not null
 #  type                    :string           not null
 #  updated_at              :datetime         not null
 #

--- a/app/models/project_group.rb
+++ b/app/models/project_group.rb
@@ -47,6 +47,9 @@ class ProjectGroup < TimelineEntry
   before_create :ensure_single_root
   before_update :check_parent_changes
 
+  # A step type value is required for timeline entries
+  after_initialize :set_step_type_value
+
   # Prepend required to work with has_closure_tree,
   # otherwise children are deleted before we even get here.
   before_destroy :validate_no_children, prepend: true
@@ -159,5 +162,9 @@ class ProjectGroup < TimelineEntry
     elsif parent_id_changed? && parent_id.nil?
       raise ArgumentError.new("Parent of project group cannot be empty")
     end
+  end
+
+  def set_step_type_value
+    self.step_type_value = "group"
   end
 end

--- a/app/models/project_step.rb
+++ b/app/models/project_step.rb
@@ -299,7 +299,7 @@ class ProjectStep < TimelineEntry
     if is_finalized?
       false
     else
-      update!(is_finalized: true)
+      update_attribute(:is_finalized, true)
     end
   end
 

--- a/app/models/project_step.rb
+++ b/app/models/project_step.rb
@@ -16,7 +16,7 @@
 #  schedule_parent_id      :integer
 #  scheduled_duration_days :integer          default(0)
 #  scheduled_start_date    :date
-#  step_type_value         :string
+#  step_type_value         :string           not null
 #  type                    :string           not null
 #  updated_at              :datetime         not null
 #

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -16,7 +16,7 @@
 #  schedule_parent_id      :integer
 #  scheduled_duration_days :integer          default(0)
 #  scheduled_start_date    :date
-#  step_type_value         :string
+#  step_type_value         :string           not null
 #  type                    :string           not null
 #  updated_at              :datetime         not null
 #

--- a/db/migrate/20170419144544_add_not_null_constraint_to_project_step_value.rb
+++ b/db/migrate/20170419144544_add_not_null_constraint_to_project_step_value.rb
@@ -1,0 +1,9 @@
+class AddNotNullConstraintToProjectStepValue < ActiveRecord::Migration
+  def up
+    execute("UPDATE timeline_entries SET step_type_value = 'group' WHERE type = 'ProjectGroup'")
+    execute("UPDATE timeline_entries SET step_type_value = 'checkin'
+      WHERE step_type_value = '' OR step_type_value IS NULL")
+    change_column_null :timeline_entries, :step_type_value, false
+  end
+end
+``

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170328160210) do
+ActiveRecord::Schema.define(version: 20170419144544) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -354,7 +354,7 @@ ActiveRecord::Schema.define(version: 20170328160210) do
     t.integer  "schedule_parent_id"
     t.integer  "scheduled_duration_days", default: 0
     t.date     "scheduled_start_date"
-    t.string   "step_type_value"
+    t.string   "step_type_value", null: false
     t.string   "type", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
- On batch finalize of steps, use update method without validation
- Fix bug where batch finalize does not work for steps without step type
- Make step type value not be null or empty
- Set project groups to have a step type value
- Set project steps to have a step type value