### PR TITLE
6394 display steps as spans in calendar

### DIFF
--- a/app/assets/javascripts/backbone/views/calendar_view.coffee
+++ b/app/assets/javascripts/backbone/views/calendar_view.coffee
@@ -33,6 +33,7 @@ class MS.Views.CalendarView extends Backbone.View
   # Load custom content inside the rendered event rather than title only
   eventAfterRender: (calEvent, initialElement) ->
     $(initialElement).find('.fc-content').append(calEvent.html)
+    console.log(calEvent.event_classes)
 
   eventDrop: (event, delta, revertFunc) ->
     if event.model_type == 'ProjectStep'

--- a/app/assets/javascripts/backbone/views/calendar_view.coffee
+++ b/app/assets/javascripts/backbone/views/calendar_view.coffee
@@ -8,7 +8,6 @@ class MS.Views.CalendarView extends Backbone.View
     @$calendar = @$('#calendar')
     @stepModal = params.stepModal
     defaultCalendarSettings =
-      # eventRender: @eventRender.bind(context)
       eventAfterRender: @eventAfterRender.bind(context)
       eventDrop: @eventDrop.bind(context)
       loading: @loading.bind(context)
@@ -27,10 +26,7 @@ class MS.Views.CalendarView extends Backbone.View
       @stepModal.new(@$el.find('#calendar').data('project-id'), @refresh.bind(@),
         date: date.format('YYYY-MM-DD'))
 
-  # Changes the default event render to load in html rather than title only
-  eventRender: (calEvent) -> calEvent.html
-
-  # Load custom content inside the rendered event rather than title only
+  # Load custom content inside the fullCalendar rendered event rather than title only
   eventAfterRender: (calEvent, initialElement) ->
     $(initialElement).find('.fc-content').append(calEvent.html)
     $(initialElement).addClass(calEvent.event_classes)

--- a/app/assets/javascripts/backbone/views/calendar_view.coffee
+++ b/app/assets/javascripts/backbone/views/calendar_view.coffee
@@ -34,7 +34,7 @@ class MS.Views.CalendarView extends Backbone.View
   eventAfterRender: (calEvent, initialElement) ->
     $(initialElement).find('.fc-content').append(calEvent.html)
     $(initialElement).addClass(calEvent.event_classes)
-    # $(initialElement).data('step-id', cal_event.model_id)
+    $(initialElement).data('step-id', calEvent.model_id)
 
   eventDrop: (event, delta, revertFunc) ->
     if event.model_type == 'ProjectStep'

--- a/app/assets/javascripts/backbone/views/calendar_view.coffee
+++ b/app/assets/javascripts/backbone/views/calendar_view.coffee
@@ -33,7 +33,8 @@ class MS.Views.CalendarView extends Backbone.View
   # Load custom content inside the rendered event rather than title only
   eventAfterRender: (calEvent, initialElement) ->
     $(initialElement).find('.fc-content').append(calEvent.html)
-    console.log(calEvent.event_classes)
+    $(initialElement).addClass(calEvent.event_classes)
+    # $(initialElement).data('step-id', cal_event.model_id)
 
   eventDrop: (event, delta, revertFunc) ->
     if event.model_type == 'ProjectStep'

--- a/app/assets/javascripts/backbone/views/calendar_view.coffee
+++ b/app/assets/javascripts/backbone/views/calendar_view.coffee
@@ -31,6 +31,7 @@ class MS.Views.CalendarView extends Backbone.View
     $(initialElement).find('.fc-content').append(calEvent.html)
     $(initialElement).addClass(calEvent.event_classes)
     $(initialElement).data('step-id', calEvent.model_id)
+    $(initialElement).find('.fc-title').remove()
 
   eventDrop: (event, delta, revertFunc) ->
     if event.model_type == 'ProjectStep'

--- a/app/assets/javascripts/backbone/views/calendar_view.coffee
+++ b/app/assets/javascripts/backbone/views/calendar_view.coffee
@@ -8,8 +8,8 @@ class MS.Views.CalendarView extends Backbone.View
     @$calendar = @$('#calendar')
     @stepModal = params.stepModal
     defaultCalendarSettings =
-      # Changes the default event render to load in html rather than title only
-      eventRender: @eventRender.bind(context)
+      # eventRender: @eventRender.bind(context)
+      eventAfterRender: @eventAfterRender.bind(context)
       eventDrop: @eventDrop.bind(context)
       loading: @loading.bind(context)
       events: params.calendarEventsUrl
@@ -27,7 +27,12 @@ class MS.Views.CalendarView extends Backbone.View
       @stepModal.new(@$el.find('#calendar').data('project-id'), @refresh.bind(@),
         date: date.format('YYYY-MM-DD'))
 
+  # Changes the default event render to load in html rather than title only
   eventRender: (calEvent) -> calEvent.html
+
+  # Load custom content inside the rendered event rather than title only
+  eventAfterRender: (calEvent, initialElement) ->
+    $(initialElement).find('.fc-content').append(calEvent.html)
 
   eventDrop: (event, delta, revertFunc) ->
     if event.model_type == 'ProjectStep'

--- a/app/assets/stylesheets/admin/calendar/_calendar.scss
+++ b/app/assets/stylesheets/admin/calendar/_calendar.scss
@@ -19,11 +19,6 @@
     font-size: .8em;
     cursor: default;
 
-    // Default title event is hidden. TODO: Remove from DOM
-    .fc-title {
-      display: none;
-    }
-
     .fa {
       display: inline;
       vertical-align: top;

--- a/app/assets/stylesheets/admin/calendar/_calendar.scss
+++ b/app/assets/stylesheets/admin/calendar/_calendar.scss
@@ -1,12 +1,18 @@
 @import "../colors";
 
 .calendar {
+  .fc-event {
+    border: none;
+    background: $background-gray;
+    color: $black;
+  }
+
   .calendar-event {
     margin-bottom: .25em;
     padding: .25em;
-    background: $background-gray;
-    color: $black;
-    border-radius: 0;
+    // background: $background-gray;
+    // color: $black;
+    // border-radius: .5em;
     max-height: 4em;
     overflow-y: hidden;
     font-size: .8em;

--- a/app/assets/stylesheets/admin/calendar/_calendar.scss
+++ b/app/assets/stylesheets/admin/calendar/_calendar.scss
@@ -5,22 +5,24 @@
     border: none;
     background: $background-gray;
     color: $black;
-  }
-
-  .calendar-event {
-    margin-bottom: .25em;
-    padding: .25em;
-    // background: $background-gray;
-    // color: $black;
-    // border-radius: .5em;
-    max-height: 4em;
-    overflow-y: hidden;
-    font-size: .8em;
-    cursor: default;
 
     // All events have a border the same color as the default bg color
     // so that they will be the same height as events with actual borders.
     border: 1px solid $background-gray;
+  }
+
+  .calendar-event {
+    margin-bottom: .25em;
+    padding: .25em .5em;
+    max-height: 4em;
+    overflow: hidden;
+    font-size: .8em;
+    cursor: default;
+
+    // Default title event is hidden. TODO: Remove from DOM
+    .fc-title {
+      display: none;
+    }
 
     .fa {
       display: inline;
@@ -30,11 +32,12 @@
 
       &.fa-link {
         color: $gray3;
+        padding-right: .25em;
       }
     }
 
     .event-title {
-      display: inline-block;
+      display: inline;
       background: inherit;
 
       .fa {
@@ -58,7 +61,7 @@
 
     .large-left-box {
       background: inherit;
-      width: calc(100% - 2em);
+      width: calc(100% - 3em);
       display: inline-block;
       max-height: 3em;
       overflow: hidden;
@@ -68,7 +71,7 @@
     }
 
     .small-right-box {
-      width: 2em;
+      width: 3em;
       display: inline-block;
       vertical-align: top;
       margin: 0;

--- a/app/models/calendar_event.rb
+++ b/app/models/calendar_event.rb
@@ -11,6 +11,8 @@ class CalendarEvent
   attr_accessor :model_type
 
   attr_accessor :backgroundColor # fullCalendar attribute
+  attr_accessor :event_classes
+
   attr_accessor :step_type
   attr_accessor :completion_status
   attr_accessor :time_status

--- a/app/models/calendar_event.rb
+++ b/app/models/calendar_event.rb
@@ -10,7 +10,7 @@ class CalendarEvent
   attr_accessor :model
   attr_accessor :model_type
 
-  attr_accessor :backgroundColor # fullCalendar attribute
+  attr_accessor :background_color
   attr_accessor :event_classes
 
   attr_accessor :step_type
@@ -93,7 +93,7 @@ class CalendarEvent
     @start = step.calendar_start_date
     @end = step.calendar_end_date
     @title = step.name.to_s
-    @backgroundColor = step.color
+    @background_color = step.color
 
     @event_type = "project_step"
     @num_of_logs = step.logs_count

--- a/app/models/calendar_event.rb
+++ b/app/models/calendar_event.rb
@@ -27,7 +27,7 @@ class CalendarEvent
     when Loan
       [new_project_start(item), new_project_end(item)]
     when ProjectStep
-      [new_project_step(item), new_ghost_step(item)]
+      [new_project_step(item)]
     else
       raise "CalendarEvent.build_for - unexpected model class: #{item.class}"
     end.compact

--- a/app/models/calendar_event.rb
+++ b/app/models/calendar_event.rb
@@ -148,8 +148,8 @@ class CalendarEvent
   end
 
   def step_start(step)
-    if step.actual_end_date
-      step.scheduled_start_date > step.actual_end_date ? step.actual_end_date : step.scheduled_start_date
+    if step.actual_end_date && step.scheduled_start_date > step.actual_end_date
+      step.actual_end_date
     else
       step.scheduled_start_date
     end

--- a/app/models/calendar_event.rb
+++ b/app/models/calendar_event.rb
@@ -10,7 +10,7 @@ class CalendarEvent
   attr_accessor :model
   attr_accessor :model_type
 
-  attr_accessor :background_color
+  attr_accessor :backgroundColor # fullCalendar attribute
   attr_accessor :step_type
   attr_accessor :completion_status
   attr_accessor :time_status
@@ -91,7 +91,7 @@ class CalendarEvent
     @start = step.scheduled_start_date
     @end = step.display_end_date
     @title = step.name.to_s
-    @background_color = step.color
+    @backgroundColor = step.color
 
     @event_type = "project_step"
     @num_of_logs = step.logs_count

--- a/app/models/calendar_event.rb
+++ b/app/models/calendar_event.rb
@@ -2,6 +2,7 @@ class CalendarEvent
   include ActiveModel::Serialization
 
   attr_accessor :start
+  attr_accessor :end
   attr_accessor :title
   attr_accessor :html  # transient value populated by controller and serialized as "title"
 
@@ -88,6 +89,7 @@ class CalendarEvent
 
   def initialize_project_step(step)
     @start = step.scheduled_start_date
+    @end = step.display_end_date
     @title = step.name.to_s
     @background_color = step.color
 
@@ -105,6 +107,7 @@ class CalendarEvent
 
   def initialize_ghost_step(step)
     @start = step.old_start_date
+    @end = step.display_end_date
     @title = step.name.to_s
     @event_type = "ghost_step"
     @num_of_logs = step.logs_count
@@ -116,6 +119,7 @@ class CalendarEvent
 
   def initialize_project_start(project)
     @start = project.signing_date
+    @end = project.signing_date
     @title = I18n.t("loan.start", name: project.display_name)
     @event_type = "project_start"
     @model_type = project.type
@@ -125,6 +129,7 @@ class CalendarEvent
 
   def initialize_project_end(project)
     @start = project.end_date
+    @end = project.end_date
     @title = I18n.t("loan.end", name: project.display_name)
     @event_type = "project_end"
     @model_type = project.type

--- a/app/models/calendar_event.rb
+++ b/app/models/calendar_event.rb
@@ -90,8 +90,8 @@ class CalendarEvent
   end
 
   def initialize_project_step(step)
-    @start = step.calendar_start_date
-    @end = step.calendar_end_date
+    @start = step_start(step)
+    @end = step.display_end_date
     @title = step.name.to_s
     @background_color = step.color
 
@@ -145,5 +145,13 @@ class CalendarEvent
 
   def model_id
     model.id
+  end
+
+  def step_start(step)
+    if step.actual_end_date
+      step.scheduled_start_date > step.actual_end_date ? step.actual_end_date : step.scheduled_start_date
+    else
+      step.scheduled_start_date
+    end
   end
 end

--- a/app/models/calendar_event.rb
+++ b/app/models/calendar_event.rb
@@ -90,8 +90,8 @@ class CalendarEvent
   end
 
   def initialize_project_step(step)
-    @start = step.scheduled_start_date
-    @end = step.display_end_date
+    @start = step.calendar_start_date
+    @end = step.calendar_end_date
     @title = step.name.to_s
     @backgroundColor = step.color
 

--- a/app/models/project_step.rb
+++ b/app/models/project_step.rb
@@ -144,19 +144,6 @@ class ProjectStep < TimelineEntry
     actual_end_date || scheduled_end_date
   end
 
-  def calendar_start_date
-    # If an item is completed before its scheduled start date, display event on end date
-    if actual_end_date
-      scheduled_start_date > actual_end_date ? actual_end_date : scheduled_start_date
-    else
-      scheduled_start_date
-    end
-  end
-
-  def calendar_end_date
-    display_end_date
-  end
-
   # Gets best known duration. nil if both start and end dates are nil.
   def display_duration_days
     if display_start_date.nil? && display_end_date.nil?

--- a/app/models/project_step.rb
+++ b/app/models/project_step.rb
@@ -144,6 +144,19 @@ class ProjectStep < TimelineEntry
     actual_end_date || scheduled_end_date
   end
 
+  def calendar_start_date
+    # If an item is completed before its scheduled start date, display event on end date
+    if actual_end_date
+      scheduled_start_date > actual_end_date ? actual_end_date : scheduled_start_date
+    else
+      scheduled_start_date
+    end
+  end
+
+  def calendar_end_date
+    display_end_date
+  end
+
   # Gets best known duration. nil if both start and end dates are nil.
   def display_duration_days
     if display_start_date.nil? && display_end_date.nil?

--- a/app/serializers/calendar_event_serializer.rb
+++ b/app/serializers/calendar_event_serializer.rb
@@ -22,8 +22,7 @@ class CalendarEventSerializer < ActiveModel::Serializer
 
   def event_classes
     if object.model_type == "ProjectStep"
-      "cal-step cal-step-#{object.step_type} #{object.time_status} #{object.has_precedent? ? 'has-precedent': ''} "
-      # "calendar-event cal-step cal-step-#{object.step_type} #{object.time_status} #{object.has_precedent? ? 'has-precedent': ''} "
+      "calendar-event cal-step cal-step-#{object.step_type} #{object.time_status} #{object.has_precedent? ? 'has-precedent': ''} "
     end
   end
 end

--- a/app/serializers/calendar_event_serializer.rb
+++ b/app/serializers/calendar_event_serializer.rb
@@ -1,6 +1,6 @@
 class CalendarEventSerializer < ActiveModel::Serializer
   attributes :start, :end, :html, :id, :model_id, :editable, :is_finalized, :completed, :model_type,
-    :event_type, :has_precedent?, :backgroundColor
+    :event_type, :has_precedent?, :backgroundColor, :event_classes
 
   def editable
     return false if (object.event_type == "ghost_step") || object.has_precedent?
@@ -18,5 +18,11 @@ class CalendarEventSerializer < ActiveModel::Serializer
 
   def completed
     object.model_type == "ProjectStep" ? object.model.completed? : nil
+  end
+
+  def event_classes
+    if object.model_type == "ProjectStep"
+      "cal-step-#{object.step_type} #{object.time_status} #{object.has_precedent? ? 'has-precedent': ''} "
+    end
   end
 end

--- a/app/serializers/calendar_event_serializer.rb
+++ b/app/serializers/calendar_event_serializer.rb
@@ -22,7 +22,8 @@ class CalendarEventSerializer < ActiveModel::Serializer
 
   def event_classes
     if object.model_type == "ProjectStep"
-      "cal-step-#{object.step_type} #{object.time_status} #{object.has_precedent? ? 'has-precedent': ''} "
+      "cal-step cal-step-#{object.step_type} #{object.time_status} #{object.has_precedent? ? 'has-precedent': ''} "
+      # "calendar-event cal-step cal-step-#{object.step_type} #{object.time_status} #{object.has_precedent? ? 'has-precedent': ''} "
     end
   end
 end

--- a/app/serializers/calendar_event_serializer.rb
+++ b/app/serializers/calendar_event_serializer.rb
@@ -1,5 +1,5 @@
 class CalendarEventSerializer < ActiveModel::Serializer
-  attributes :start, :html, :id, :model_id, :editable, :is_finalized, :completed, :model_type,
+  attributes :start, :end, :html, :id, :model_id, :editable, :is_finalized, :completed, :model_type,
     :event_type, :has_precedent?
 
   def editable

--- a/app/serializers/calendar_event_serializer.rb
+++ b/app/serializers/calendar_event_serializer.rb
@@ -1,6 +1,6 @@
 class CalendarEventSerializer < ActiveModel::Serializer
   attributes :start, :end, :html, :id, :model_id, :editable, :is_finalized, :completed, :model_type,
-    :event_type, :has_precedent?
+    :event_type, :has_precedent?, :backgroundColor
 
   def editable
     return false if (object.event_type == "ghost_step") || object.has_precedent?

--- a/app/serializers/calendar_event_serializer.rb
+++ b/app/serializers/calendar_event_serializer.rb
@@ -25,4 +25,8 @@ class CalendarEventSerializer < ActiveModel::Serializer
       "calendar-event cal-step cal-step-#{object.step_type} #{object.time_status} #{object.has_precedent? ? 'has-precedent': ''} "
     end
   end
+
+  def backgroundColor
+    object.background_color
+  end
 end

--- a/app/views/admin/calendar/_event.html.slim
+++ b/app/views/admin/calendar/_event.html.slim
@@ -11,34 +11,27 @@
         = cal_event.title
 
   - when "project_step"
-
-    div.calendar-event.cal-step [
-      class="cal-step-#{cal_event.step_type} #{cal_event.time_status}
-        #{cal_event.has_precedent? ? 'has-precedent': ''} "
-      style="#{(c = cal_event.backgroundColor) ? "background: #{c}" : ''}"
-      data-step-id="#{cal_event.model_id}"]
-
-      div.large-left-box
-        span.event-title
-          - if cal_event.step_type == "milestone"
-              i.fa.fa-flag
-          - else
-              i.fa.fa-calendar-check-o
-          = cal_event.title.to_s
-      div.small-right-box.right-align
-        div.align-top.top-info
-          - if cal_event.completion_status == "complete"
-              i.fa.fa-check
-          - elsif cal_event.time_status == "late"
-              i.fa.fa-clock-o
-          - else
-              i = " "
-        div.align-bottom.bottom-info
-          - if cal_event.has_precedent
-              i.fa.fa-link
-          - if cal_event.num_of_logs > 0
-              i.fa.fa-pencil-square-o
-              = cal_event.num_of_logs.to_s
+    div.large-left-box
+      span.event-title
+        - if cal_event.step_type == "milestone"
+            i.fa.fa-flag
+        - else
+            i.fa.fa-calendar-check-o
+        = cal_event.title.to_s
+    div.small-right-box.right-align
+      div.align-top.top-info
+        - if cal_event.completion_status == "complete"
+            i.fa.fa-check
+        - elsif cal_event.time_status == "late"
+            i.fa.fa-clock-o
+        - else
+            i = " "
+      div.align-bottom.bottom-info
+        - if cal_event.has_precedent
+            i.fa.fa-link
+        - if cal_event.num_of_logs > 0
+            i.fa.fa-pencil-square-o
+            = cal_event.num_of_logs.to_s
 
   - when "ghost_step"
 

--- a/app/views/admin/calendar/_event.html.slim
+++ b/app/views/admin/calendar/_event.html.slim
@@ -15,7 +15,7 @@
     div.calendar-event.cal-step [
       class="cal-step-#{cal_event.step_type} #{cal_event.time_status}
         #{cal_event.has_precedent? ? 'has-precedent': ''} "
-      style="#{(c = cal_event.background_color) ? "background: #{c}" : ''}"
+      style="#{(c = cal_event.backgroundColor) ? "background: #{c}" : ''}"
       data-step-id="#{cal_event.model_id}"]
 
       div.large-left-box

--- a/app/views/admin/calendar/_legend.html.slim
+++ b/app/views/admin/calendar/_legend.html.slim
@@ -16,9 +16,6 @@ div#legend-content
             td: span: i.fa.fa-pencil-square-o
             th = t("calendar.num_of_logs")
           tr
-            td: span.original-date
-            th = t("calendar.original_date")
-          tr
             td: span: i.fa.fa-link
             th = t("calendar.has_precedent")
 


### PR DESCRIPTION
- Convert steps in calendars to span across dates
- Bug fixes related to displayed start and end dates
- Use underlying fullCalendar structure for step events to utilize pre-built classes