### PR TITLE
6393: Show logs inside timeline edit step modal

### DIFF
--- a/app/controllers/admin/project_steps_controller.rb
+++ b/app/controllers/admin/project_steps_controller.rb
@@ -22,6 +22,7 @@ class Admin::ProjectStepsController < Admin::AdminController
 
   def edit
     @step = ProjectStep.find(params[:id])
+    @logs = @step.project_logs
     authorize @step
     render_modal_content
   end


### PR DESCRIPTION
- Fix bug that showed a no logs message in edit step modal when logs present