### PR TITLE
6574: Tempoarily remove page breaks from loan memo

### DIFF
--- a/app/assets/stylesheets/admin/loans/_questionnaires.scss
+++ b/app/assets/stylesheets/admin/loans/_questionnaires.scss
@@ -169,13 +169,14 @@ section.questionnaires {
   }
 }
 
-@media print {
-  .questionnaire-form {
-    .header {
-      page-break-before: always;
-    }
-  }
-}
+// Page breaks temporarily removed from printed loan memo
+// @media print {
+//   .questionnaire-form {
+//     .header {
+//       page-break-before: always;
+//     }
+//   }
+// }
 
 .admin-embeddable_media {
   #embeddable_media_start_cell,

--- a/app/views/admin/loans/questionnaires/_questionnaire_group.html.slim
+++ b/app/views/admin/loans/questionnaires/_questionnaire_group.html.slim
@@ -14,14 +14,15 @@
           - reopen_fieldset = true
 
         / Page header for print view
-        .header.visible-print-block
-          = @loan.division.name
-          br
-          = t("loan.print_header_title")
-          br
-          = @loan.organization.name
-          br
-          = I18n.l(Date.today, format: :long)
+        / Page headers temporarily removed from printed loan memo
+        / .header.visible-print-block
+        /   = @loan.division.name
+        /   br
+        /   = t("loan.print_header_title")
+        /   br
+        /   = @loan.organization.name
+        /   br
+        /   = I18n.l(Date.today, format: :long)
 
       - optional = !question.required_for?(@loan)
       - start_of_optional_group = !optional_encountered && optionals_exist && requireds_exist && optional


### PR DESCRIPTION
- Temporarily remove page breaks from loan memo
- Temporarily remove headings for page breaks in loan memo
- Keep page breaks on breakeven table and charts
- Fix bug where page breaks were inconsistently being applied in loan memo
- An update for how page breaks appear in loan memo is slated for the next sprint