### PR TITLE
6905 add line item model with corresponding spec

### DIFF
--- a/app/models/accounting/account.rb
+++ b/app/models/accounting/account.rb
@@ -20,6 +20,7 @@ class Accounting::Account < ActiveRecord::Base
   belongs_to :project
 
   has_many :transactions, inverse_of: :account, foreign_key: :accounting_account_id, dependent: :destroy
+  has_many :line_items, inverse_of: :account, foreign_key: :accounting_account_id, dependent: :destroy
 
   def self.find_or_create_from_qb_object(transaction_type:, qb_object:)
     account = find_or_initialize_by qb_id: qb_object.id

--- a/app/models/accounting/line_item.rb
+++ b/app/models/accounting/line_item.rb
@@ -1,0 +1,29 @@
+# == Schema Information
+#
+# Table name: accounting_line_items
+#
+#  accounting_account_id     :integer
+#  accounting_transaction_id :integer
+#  amount                    :decimal(, )
+#  created_at                :datetime         not null
+#  description               :string
+#  id                        :integer          not null, primary key
+#  posting_type              :string
+#  qb_line_id                :integer
+#  updated_at                :datetime         not null
+#
+# Indexes
+#
+#  index_accounting_line_items_on_accounting_account_id      (accounting_account_id)
+#  index_accounting_line_items_on_accounting_transaction_id  (accounting_transaction_id)
+#
+# Foreign Keys
+#
+#  fk_rails_c0f205ff31  (accounting_account_id => accounting_accounts.id)
+#  fk_rails_c987f5b811  (accounting_transaction_id => accounting_transactions.id)
+#
+
+class Accounting::LineItem < ActiveRecord::Base
+  belongs_to :accounting_transaction, class_name: 'Accounting::Transaction'
+  belongs_to :accounting_account, class_name: 'Accounting::Account'
+end

--- a/app/models/accounting/transaction.rb
+++ b/app/models/accounting/transaction.rb
@@ -42,6 +42,8 @@ class Accounting::Transaction < ActiveRecord::Base
   belongs_to :project, inverse_of: :transactions, foreign_key: :project_id
   belongs_to :currency
 
+  has_many :line_items, inverse_of: :accounting_transaction, foreign_key: :accounting_transaction_id, dependent: :destroy
+
   before_save :update_fields_from_quickbooks_data
 
   validates :loan_transaction_type, :txn_date, :amount, :accounting_account_id, presence: true

--- a/db/migrate/20170807122855_create_line_items.rb
+++ b/db/migrate/20170807122855_create_line_items.rb
@@ -1,0 +1,14 @@
+class CreateLineItems < ActiveRecord::Migration
+  def change
+    create_table :accounting_line_items do |t|
+      t.integer :qb_line_id
+      t.references :accounting_transaction, index: true, foreign_key: true
+      t.references :accounting_account, index: true, foreign_key: true
+      t.string :posting_type
+      t.string :description
+      t.decimal :amount
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170726202231) do
+ActiveRecord::Schema.define(version: 20170807122855) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,6 +25,20 @@ ActiveRecord::Schema.define(version: 20170726202231) do
   end
 
   add_index "accounting_accounts", ["qb_id"], name: "index_accounting_accounts_on_qb_id", using: :btree
+
+  create_table "accounting_line_items", force: :cascade do |t|
+    t.integer  "accounting_account_id"
+    t.integer  "accounting_transaction_id"
+    t.decimal  "amount"
+    t.datetime "created_at", null: false
+    t.string   "description"
+    t.string   "posting_type"
+    t.integer  "qb_line_id"
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "accounting_line_items", ["accounting_account_id"], name: "index_accounting_line_items_on_accounting_account_id", using: :btree
+  add_index "accounting_line_items", ["accounting_transaction_id"], name: "index_accounting_line_items_on_accounting_transaction_id", using: :btree
 
   create_table "accounting_quickbooks_connections", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -436,6 +450,8 @@ ActiveRecord::Schema.define(version: 20170726202231) do
 
   add_index "users_roles", ["user_id", "role_id"], name: "index_users_roles_on_user_id_and_role_id", unique: true, using: :btree
 
+  add_foreign_key "accounting_line_items", "accounting_accounts"
+  add_foreign_key "accounting_line_items", "accounting_transactions"
   add_foreign_key "accounting_quickbooks_connections", "divisions"
   add_foreign_key "accounting_transactions", "accounting_accounts"
   add_foreign_key "accounting_transactions", "currencies"

--- a/spec/factories/accounting_line_items.rb
+++ b/spec/factories/accounting_line_items.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :accounting_line_item, class: 'Accounting::LineItem' do
+    qb_line_id 1
+    association(:accounting_transaction)
+    association(:accounting_account)
+    posting_type "Credit"
+    description "Crediting my account"
+    amount "9.99"
+  end
+end

--- a/spec/models/accounting/line_item_spec.rb
+++ b/spec/models/accounting/line_item_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+describe Accounting::LineItem do
+  it 'has a valid factory' do
+    expect(create(:accounting_line_item)).to be_valid
+  end
+end


### PR DESCRIPTION
In the transaction model, I noticed there were two line items; one for credit and the other for debit. That being said, I'm not sure what the association is from transactions and accounts (i.e. has_many or has_one)
@hooverlunch 