### PR TITLE
7134: Show project name in show view of modal

### DIFF
--- a/app/controllers/admin/project_steps_controller.rb
+++ b/app/controllers/admin/project_steps_controller.rb
@@ -192,6 +192,7 @@ class Admin::ProjectStepsController < Admin::AdminController
 
   def render_modal_content(status = 200)
     @mode = params[:action] == "show" ? :show_and_form : :form_only
+    @project = Project.find(@step.project_id)
     @parents = @step.project.timeline_groups_preordered
     @precedents = @step.project.timeline_entries.where("type = 'ProjectStep' AND id != ?", @step.id || 0).by_date
     render partial: "/admin/project_steps/modal_content", status: status, locals: {

--- a/app/controllers/admin/project_steps_controller.rb
+++ b/app/controllers/admin/project_steps_controller.rb
@@ -192,7 +192,7 @@ class Admin::ProjectStepsController < Admin::AdminController
 
   def render_modal_content(status = 200)
     @mode = params[:action] == "show" ? :show_and_form : :form_only
-    @project = Project.find(@step.project_id)
+    @project = @step.project
     @parents = @step.project.timeline_groups_preordered
     @precedents = @step.project.timeline_entries.where("type = 'ProjectStep' AND id != ?", @step.id || 0).by_date
     render partial: "/admin/project_steps/modal_content", status: status, locals: {

--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -27,17 +27,6 @@ class Admin::ProjectsController < Admin::AdminController
     end
   end
 
-  def show
-    @project = Project.find(params[:id])
-    authorize @project, :show?
-    case @project.type
-    when 'Loan'
-      redirect_to admin_loan_tab_path(@project, tab: 'details')
-    when 'BasicProject'
-      redirect_to admin_basic_project_path(@project, tab: 'details')
-    end
-  end
-
   protected
 
   def prep_timeline(project)

--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -27,6 +27,17 @@ class Admin::ProjectsController < Admin::AdminController
     end
   end
 
+  def show
+    @project = Project.find(params[:id])
+    authorize @project, :show?
+    case @project.type
+    when 'Loan'
+      redirect_to admin_loan_tab_path(@project, tab: 'details')
+    when 'BasicProject'
+      redirect_to admin_basic_project_path(@project, tab: 'details')
+    end
+  end
+
   protected
 
   def prep_timeline(project)

--- a/app/views/admin/project_steps/_modal_content.html.slim
+++ b/app/views/admin/project_steps/_modal_content.html.slim
@@ -49,7 +49,8 @@ section.step-fields class=(@mode == :show_and_form ? 'show-view' : 'edit-view') 
       - else
         .view-element
           = f.input :project_id
-            = link_to @project.display_name, admin_project_path(@project)
+            = link_to @project.display_name,
+              send("admin_#{@project.model_name.singular}_tab_path", @project, tab: "details")
 
       / Summary & details
       .view-element

--- a/app/views/admin/project_steps/_modal_content.html.slim
+++ b/app/views/admin/project_steps/_modal_content.html.slim
@@ -38,13 +38,18 @@ section.step-fields class=(@mode == :show_and_form ? 'show-view' : 'edit-view') 
       defaults: {input_html: {class: "form-element form-control"}},
       ) do |f|
 
-      / Need to pass these through to create but not update.
-      - if @step.new_record?
-        = f.hidden_field(:project_id)
-
       = hidden_field_tag(:context, context)
 
       = error_notification(f)
+
+      / Project
+      - if @step.new_record?
+        / Need to pass this through to create but not update.
+        = f.hidden_field(:project_id)
+      - else
+        .view-element
+          = f.input :project_id
+            = @project.display_name
 
       / Summary & details
       .view-element

--- a/app/views/admin/project_steps/_modal_content.html.slim
+++ b/app/views/admin/project_steps/_modal_content.html.slim
@@ -49,7 +49,7 @@ section.step-fields class=(@mode == :show_and_form ? 'show-view' : 'edit-view') 
       - else
         .view-element
           = f.input :project_id
-            = @project.display_name
+            = link_to @project.display_name, admin_project_path(@project)
 
       / Summary & details
       .view-element


### PR DESCRIPTION
- Show project name in the show view of the project step modal
- Ensures general calendar and dashboard calendar step events have project context

The show view of the project step modal appears in all calendars, but is not displayed in the timeline.