### PR TITLE
7209 media alt text

### DIFF
--- a/app/assets/stylesheets/admin/media/_media.scss
+++ b/app/assets/stylesheets/admin/media/_media.scss
@@ -77,6 +77,7 @@ $media-block-width: 100px;
 
     a {
       display: block;
+      height: 100px;
 
       &:hover {
         text-decoration: none;

--- a/app/assets/stylesheets/admin/media/_media.scss
+++ b/app/assets/stylesheets/admin/media/_media.scss
@@ -44,9 +44,10 @@ $media-block-width: 100px;
   }
 
   .thumb {
+    position: relative;
+    max-width: 100px;
     margin-bottom: 15px;
     margin-right: 15px;
-    position: relative;
 
     .actions {
       display: none;

--- a/app/helpers/media_helper.rb
+++ b/app/helpers/media_helper.rb
@@ -1,7 +1,8 @@
 module MediaHelper
   def media_thumbnail(media_item)
     if media_item.thumbnail?
-      image_tag(media_item.item.thumb.url)
+      alt_text = truncate(media_item.caption.text, length: 36)
+      return image_tag(media_item.item.thumb.url, alt: alt_text)
     else
       content_tag(:div, class: "media-block") do
         concat(content_tag(:div, media_item.kind_value.capitalize))


### PR DESCRIPTION
- Ensure media image alt text does not take up more room than expected
- Use the caption as alt text, if available, instead of auto-generated alt text