### PR TITLE
5938 fix filtering:

### DIFF
--- a/app/views/admin/basic_projects/_basic_projects_grid_definition.html.slim
+++ b/app/views/admin/basic_projects/_basic_projects_grid_definition.html.slim
@@ -25,10 +25,7 @@
     - g.column name: t('loan.agent.secondary', count: 2), attribute: 'secondary_agent_id',
       custom_filter: Person.filter_in_division(selected_division), detach_with_id: :sec_agent_filter do |project|
       - project.secondary_agent.try(:name)
-    / - g.column name: t('basic_project.agent', count: 2), attribute: 'name',
-      assoc: :primary_agent, in_html: true, in_csv: false, filter: true,
-      filter_type: :custom_agent_filter, detach_with_id: :agent_filter do |project|
-      - project.display_agent_names
+
     - g.column name: t('activerecord.attributes.basic_project.primary_agent'), filter: false,
       in_html: false do |project|
       - project.primary_agent.try(:name)

--- a/app/views/admin/basic_projects/_basic_projects_grid_definition.html.slim
+++ b/app/views/admin/basic_projects/_basic_projects_grid_definition.html.slim
@@ -16,7 +16,16 @@
       detach_with_id: :status_filter do |project|
       - project.status
 
-    - g.column name: t('basic_project.agent', count: 2), attribute: 'name',
+    / Wice grid filters by db column. Having either primary_agent or secondary_agent will cause the agents to
+      be filtered by that one column so the filter is incomplete
+    / According to https://github.com/leikind/wice_grid/issues/216, the solution would be to create another column
+    - g.column name: t('loan.agent.primary', count: 2), attribute: 'primary_agent_id',
+      custom_filter: Person.filter_in_division(selected_division), detach_with_id: :pry_agent_filter do |project|
+      - project.primary_agent.try(:name)
+    - g.column name: t('loan.agent.secondary', count: 2), attribute: 'secondary_agent_id',
+      custom_filter: Person.filter_in_division(selected_division), detach_with_id: :sec_agent_filter do |project|
+      - project.secondary_agent.try(:name)
+    / - g.column name: t('basic_project.agent', count: 2), attribute: 'name',
       assoc: :primary_agent, in_html: true, in_csv: false, filter: true,
       filter_type: :custom_agent_filter, detach_with_id: :agent_filter do |project|
       - project.display_agent_names

--- a/app/views/admin/basic_projects/index.html.slim
+++ b/app/views/admin/basic_projects/index.html.slim
@@ -20,10 +20,15 @@
         .filter-content
           = grid_filter(@basic_projects_grid, :status_filter)
 
-      .filter.larger-text-box
-        label = t('basic_project.agent', count: 1)
+      .filter
+        label = t('activerecord.attributes.basic_project.primary_agent')
         .filter-content
-          = grid_filter(@basic_projects_grid, :agent_filter)
+          = grid_filter(@basic_projects_grid, :pry_agent_filter)
+
+      .filter
+        label = t('activerecord.attributes.basic_project.secondary_agent')
+        .filter-content
+          = grid_filter(@basic_projects_grid, :sec_agent_filter)
 
       .filter
         label = t("activerecord.attributes.basic_project.signing_date")

--- a/app/views/admin/loans/_loans_grid_definition.html.slim
+++ b/app/views/admin/loans/_loans_grid_definition.html.slim
@@ -41,9 +41,15 @@
     - g.column name: t('activerecord.attributes.loan.currency'), attribute: 'symbol',
       assoc: :currency, filter: false, in_html: false
 
-    - g.column name: t('loan.agent', count: 2), in_csv: false, attribute: 'name', assoc: :primary_agent,
-      filter: true, in_html: true, filter_type: :custom_agent_filter, detach_with_id: :agent_filter do |loan|
-      - loan.display_agent_names
+    / Wice grid filters by db column. Having either primary_agent or secondary_agent will cause the agents to
+      be filtered by that one column so the filter is incomplete
+    / According to https://github.com/leikind/wice_grid/issues/216, the solution would be to create another column
+    - g.column name: t('loan.agent.primary', count: 1), attribute: 'primary_agent_id',
+      custom_filter: Person.filter_in_division(selected_division), detach_with_id: :pry_agent_filter do |loan|
+      - loan.primary_agent.try(:name)
+    - g.column name: t('loan.agent.secondary', count: 1), attribute: 'secondary_agent_id',
+      custom_filter: Person.filter_in_division(selected_division), detach_with_id: :sec_agent_filter do |loan|
+      - loan.secondary_agent.try(:name)
 
     / These need use a custom format, otherwise they will confuse the :custom_agent_filter
     - g.column name: t('activerecord.attributes.loan.primary_agent'), filter: false, in_html: false do |loan|

--- a/app/views/admin/loans/index.html.slim
+++ b/app/views/admin/loans/index.html.slim
@@ -45,10 +45,15 @@
         .filter-content.dates
           = grid_filter(@loans_grid, :end_date_filter)
 
-      .filter.larger-text-box
-        label = t("loan.agent", count: 1)
+      .filter
+        label = t("loan.agent.primary", count: 1)
         .filter-content
-          = grid_filter(@loans_grid, :agent_filter)
+          = grid_filter(@loans_grid, :pry_agent_filter)
+
+      .filter
+        label = t("loan.agent.secondary", count: 1)
+        .filter-content
+          = grid_filter(@loans_grid, :sec_agent_filter)
 
       .actions
         button.btn.btn-link.wg-external-reset-button data-grid-name="loans"

--- a/config/locales/en/loans.en.yml
+++ b/config/locales/en/loans.en.yml
@@ -3,6 +3,8 @@ en:
     adjust_dates: "Adjust Dates"
     adjust_scheduled_dates: "Adjust Scheduled Dates"
     agent:
+      primary: 'Primary Agent'
+      secondary: 'Secondary Agent'
       one: "Agent"
       other: "Agents"
     amount: "Amount"


### PR DESCRIPTION
Wice grid filters by db column. Having either primary_agent or secondary_agent will cause the agents tovbe filtered by that one column so the filter is incomplete
According to https://github.com/leikind/wice_grid/issues/216, the solution would be to create another column which I think is not necessary