### PR TITLE
7998: Add alternative url for deploying

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -3,6 +3,8 @@ lock '3.10.0'
 
 set :application, 'madeline'
 
+# If you have problems deploying, use the below https url instead
+# set :repo_url, 'https://github.com/sassafrastech/madeline.git'
 set :repo_url, 'git@github.com:sassafrastech/madeline_system.git'
 
 set :tmp_dir, '/home/deploy/tmp'


### PR DESCRIPTION
Fixes a bug where one developer was unable to deploy.

The initial pull request was here. https://github.com/sassafrastech/madeline/pull/469