### PR TITLE
8003 skip locked txns

### DIFF
--- a/app/controllers/admin/accounting/transactions_controller.rb
+++ b/app/controllers/admin/accounting/transactions_controller.rb
@@ -29,6 +29,7 @@ class Admin::Accounting::TransactionsController < Admin::AdminController
     @loan = Loan.find(transaction_params[:project_id])
     authorize(@loan, :update?)
     @transaction = ::Accounting::Transaction.new(transaction_params)
+    @transaction.managed = true
     process_transaction_and_handle_errors
 
     # Since the txn has already been saved and/or validated before qb errors are added,

--- a/app/models/accounting/interest_calculator.rb
+++ b/app/models/accounting/interest_calculator.rb
@@ -87,6 +87,7 @@ module Accounting
         txns.concat(txns_by_date[date]) if txns_by_date[date]
 
         txns.each do |tx|
+          next if tx.locked?
           case tx.loan_transaction_type_value
             when "interest"
               tx.amount = accrued_interest(prev_tx, tx)

--- a/app/models/accounting/transaction.rb
+++ b/app/models/accounting/transaction.rb
@@ -67,9 +67,9 @@ class Accounting::Transaction < ActiveRecord::Base
   has_many :line_items, inverse_of: :parent_transaction, autosave: true,
     foreign_key: :accounting_transaction_id, dependent: :destroy
 
-  validates :loan_transaction_type_value, :txn_date, presence: true
-  validates :amount, presence: true, unless: :interest?
-  validates :accounting_account_id, presence: true, unless: :interest?
+  validates :loan_transaction_type_value, :txn_date, presence: true, if: :managed?
+  validates :amount, presence: true, unless: :interest?, if: :managed?
+  validates :accounting_account_id, presence: true, unless: :interest?, if: :managed?
 
   delegate :division, :qb_division, to: :project
 

--- a/app/models/accounting/transaction.rb
+++ b/app/models/accounting/transaction.rb
@@ -10,6 +10,7 @@
 #  id                          :integer          not null, primary key
 #  interest_balance            :decimal(, )      default(0.0)
 #  loan_transaction_type_value :string
+#  locked                      :boolean          default(TRUE), not null
 #  needs_qb_push               :boolean          default(TRUE), not null
 #  principal_balance           :decimal(, )      default(0.0)
 #  private_note                :string

--- a/app/models/accounting/transaction.rb
+++ b/app/models/accounting/transaction.rb
@@ -10,7 +10,7 @@
 #  id                          :integer          not null, primary key
 #  interest_balance            :decimal(, )      default(0.0)
 #  loan_transaction_type_value :string
-#  locked                      :boolean          default(TRUE), not null
+#  managed                     :boolean          default(FALSE), not null
 #  needs_qb_push               :boolean          default(TRUE), not null
 #  principal_balance           :decimal(, )      default(0.0)
 #  private_note                :string

--- a/db/migrate/20180222124353_add_locked_to_transactions.rb
+++ b/db/migrate/20180222124353_add_locked_to_transactions.rb
@@ -1,0 +1,5 @@
+class AddLockedToTransactions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :accounting_transactions, :locked, :boolean, default: true, null: false
+  end
+end

--- a/db/migrate/20180306112918_remove_lock_add_managed.rb
+++ b/db/migrate/20180306112918_remove_lock_add_managed.rb
@@ -1,0 +1,6 @@
+class RemoveLockAddManaged < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :accounting_transactions, :locked
+    add_column :accounting_transactions, :managed, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180222124353) do
+ActiveRecord::Schema.define(version: 20180306112918) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -68,7 +68,7 @@ ActiveRecord::Schema.define(version: 20180222124353) do
     t.decimal "total"
     t.date "txn_date"
     t.datetime "updated_at", null: false
-    t.boolean "locked", default: true, null: false
+    t.boolean "managed", default: false, null: false
     t.index ["accounting_account_id"], name: "index_accounting_transactions_on_accounting_account_id"
     t.index ["currency_id"], name: "index_accounting_transactions_on_currency_id"
     t.index ["project_id"], name: "index_accounting_transactions_on_project_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180130145027) do
+ActiveRecord::Schema.define(version: 20180222124353) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -69,6 +68,7 @@ ActiveRecord::Schema.define(version: 20180130145027) do
     t.decimal "total"
     t.date "txn_date"
     t.datetime "updated_at", null: false
+    t.boolean "locked", default: true, null: false
     t.index ["accounting_account_id"], name: "index_accounting_transactions_on_accounting_account_id"
     t.index ["currency_id"], name: "index_accounting_transactions_on_currency_id"
     t.index ["project_id"], name: "index_accounting_transactions_on_project_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +13,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 20180306112918) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -58,6 +59,7 @@ ActiveRecord::Schema.define(version: 20180306112918) do
     t.string "description"
     t.decimal "interest_balance", default: "0.0"
     t.string "loan_transaction_type_value"
+    t.boolean "managed", default: false, null: false
     t.boolean "needs_qb_push", default: true, null: false
     t.decimal "principal_balance", default: "0.0"
     t.string "private_note"
@@ -68,7 +70,6 @@ ActiveRecord::Schema.define(version: 20180306112918) do
     t.decimal "total"
     t.date "txn_date"
     t.datetime "updated_at", null: false
-    t.boolean "managed", default: false, null: false
     t.index ["accounting_account_id"], name: "index_accounting_transactions_on_accounting_account_id"
     t.index ["currency_id"], name: "index_accounting_transactions_on_currency_id"
     t.index ["project_id"], name: "index_accounting_transactions_on_project_id"

--- a/spec/factories/accounting_transactions.rb
+++ b/spec/factories/accounting_transactions.rb
@@ -10,7 +10,7 @@
 #  id                          :integer          not null, primary key
 #  interest_balance            :decimal(, )      default(0.0)
 #  loan_transaction_type_value :string
-#  locked                      :boolean          default(TRUE), not null
+#  managed                     :boolean          default(FALSE), not null
 #  needs_qb_push               :boolean          default(TRUE), not null
 #  principal_balance           :decimal(, )      default(0.0)
 #  private_note                :string
@@ -54,6 +54,7 @@ FactoryBot.define do
     amount { Faker::Number.decimal(4, 2) }
     account
     project
+    managed true
 
     trait :interest do
       loan_transaction_type_value 'interest'
@@ -106,6 +107,10 @@ FactoryBot.define do
         create(:line_item, parent_transaction: txn, account: evaluator.division.principal_account,
           posting_type: 'credit', amount: evaluator.amount.to_f / 2)
       end
+    end
+
+    trait :unmanaged do
+      managed false
     end
   end
 end

--- a/spec/factories/accounting_transactions.rb
+++ b/spec/factories/accounting_transactions.rb
@@ -77,7 +77,7 @@ FactoryBot.define do
 
       after(:create) do |txn, evaluator|
         create(:line_item, parent_transaction: txn, account: evaluator.division.interest_receivable_account,
-          posting_type: 'debit', amount: evaluator.amount)
+          posting_type: 'Debit', amount: evaluator.amount)
         create(:line_item, parent_transaction: txn, account: evaluator.division.interest_income_account,
           posting_type: 'credit', amount: evaluator.amount)
       end
@@ -89,9 +89,9 @@ FactoryBot.define do
 
       after(:create) do |txn, evaluator|
         create(:line_item, parent_transaction: txn, account: txn.account,
-          posting_type: 'credit', amount: evaluator.amount)
+          posting_type: 'Credit', amount: evaluator.amount)
         create(:line_item, parent_transaction: txn, account: evaluator.division.principal_account,
-          posting_type: 'debit', amount: evaluator.amount)
+          posting_type: 'Debit', amount: evaluator.amount)
       end
     end
 
@@ -101,11 +101,11 @@ FactoryBot.define do
 
       after(:create) do |txn, evaluator|
         create(:line_item, parent_transaction: txn, account: txn.account,
-          posting_type: 'debit', amount: evaluator.amount)
+          posting_type: 'Debit', amount: evaluator.amount)
         create(:line_item, parent_transaction: txn, account: evaluator.division.interest_receivable_account,
-          posting_type: 'credit', amount: evaluator.amount.to_f / 2)
+          posting_type: 'Credit', amount: evaluator.amount.to_f / 2)
         create(:line_item, parent_transaction: txn, account: evaluator.division.principal_account,
-          posting_type: 'credit', amount: evaluator.amount.to_f / 2)
+          posting_type: 'Credit', amount: evaluator.amount.to_f / 2)
       end
     end
 

--- a/spec/factories/accounting_transactions.rb
+++ b/spec/factories/accounting_transactions.rb
@@ -10,6 +10,7 @@
 #  id                          :integer          not null, primary key
 #  interest_balance            :decimal(, )      default(0.0)
 #  loan_transaction_type_value :string
+#  locked                      :boolean          default(TRUE), not null
 #  needs_qb_push               :boolean          default(TRUE), not null
 #  principal_balance           :decimal(, )      default(0.0)
 #  private_note                :string

--- a/spec/models/accounting/interest_calculator_spec.rb
+++ b/spec/models/accounting/interest_calculator_spec.rb
@@ -10,8 +10,8 @@ describe Accounting::InterestCalculator do
       project: loan, txn_date: "2017-01-01", division: division) }
     let!(:t1) { create(:accounting_transaction, loan_transaction_type_value: "interest", amount: nil,
       project: loan, txn_date: "2017-01-04", division: division) }
-    let!(:t2) { create(:accounting_transaction, loan_transaction_type_value: "disbursement", amount: 17.50,
-      project: loan, txn_date: "2017-01-04", division: division) }
+    let!(:t2) { create(:accounting_transaction, :unmanaged, loan_transaction_type_value: "disbursement",
+      amount: 17.50, project: loan, txn_date: "2017-01-04", division: division) }
     let!(:t3) { create(:accounting_transaction, loan_transaction_type_value: "interest", amount: nil,
       project: loan, txn_date: "2017-01-31", division: division) }
     let!(:t4) { create(:accounting_transaction, loan_transaction_type_value: "repayment", amount: 0.50,
@@ -29,8 +29,14 @@ describe Accounting::InterestCalculator do
         # Initial computation
         recalculate_and_reload
 
-        # All transactions should get their push flags set because they didn't have any line items before.
-        expect(all_txns.map(&:needs_qb_push).uniq).to eq [true]
+        # All transactions except t2 should get their push flags set because they didn't have any line items before.
+        # t2 is not managed
+        expect(t0.needs_qb_push).to be_truthy
+        expect(t1.needs_qb_push).to be_truthy
+        expect(t2.needs_qb_push).to be_falsey
+        expect(t3.needs_qb_push).to be_truthy
+        expect(t4.needs_qb_push).to be_truthy
+        expect(t5.needs_qb_push).to be_truthy
 
         # t0 --------------------------------------------------------
         expect(t0.line_items.size).to eq(2)

--- a/spec/models/accounting/transaction_spec.rb
+++ b/spec/models/accounting/transaction_spec.rb
@@ -10,6 +10,7 @@
 #  id                          :integer          not null, primary key
 #  interest_balance            :decimal(, )      default(0.0)
 #  loan_transaction_type_value :string
+#  locked                      :boolean          default(TRUE), not null
 #  needs_qb_push               :boolean          default(TRUE), not null
 #  principal_balance           :decimal(, )      default(0.0)
 #  private_note                :string

--- a/spec/models/accounting/transaction_spec.rb
+++ b/spec/models/accounting/transaction_spec.rb
@@ -10,7 +10,7 @@
 #  id                          :integer          not null, primary key
 #  interest_balance            :decimal(, )      default(0.0)
 #  loan_transaction_type_value :string
-#  locked                      :boolean          default(TRUE), not null
+#  managed                     :boolean          default(FALSE), not null
 #  needs_qb_push               :boolean          default(TRUE), not null
 #  principal_balance           :decimal(, )      default(0.0)
 #  private_note                :string


### PR DESCRIPTION
I stopped at the point where it says line_items should remain the same in the story. Skipping managed transactions will prevent the line items from being created all together.

Does this mean moving the condition to after the line items are created?
