### PR TITLE
8119: Remove QuickBooks connection error message on production

### DIFF
--- a/app/models/accounting/quickbooks/updater.rb
+++ b/app/models/accounting/quickbooks/updater.rb
@@ -27,6 +27,10 @@ module Accounting
       #
       # This argument can either be a single loan or an array of loans
       def update(loans = nil)
+        # Production uses a non-sandbox QuickBooks instance, which may or may not be active at any
+        # given point in time.
+        return if Rails.env.production? && !qb_connection
+
         raise NotConnectedError unless qb_connection
         return if too_soon_to_run_again?
 


### PR DESCRIPTION
We are getting hundreds of emails because Madeline production does not have an active QuickBooks account connected to it. If QuickBooks is not connected on production, this does not indicate a failure. It could be an intentional choice (which it is in this instance). Please see Redmine for more details.