### PR TITLE
8760: Fixes CSV Exports

### DIFF
--- a/config/initializers/wice_grid_config.rb
+++ b/config/initializers/wice_grid_config.rb
@@ -35,7 +35,7 @@ if defined?(Wice::Defaults)
   Wice::Defaults::CSV_FIELD_SEPARATOR = ','
 
   # Default CSV encoding (p.e. 'CP1252:UTF-8' to make Microsoft Excel(tm) happy)
-  Wice::Defaults::CSV_ENCODING = 'CP1252:UTF-8'
+  Wice::Defaults::CSV_ENCODING = nil
 
   # The strategy when to show the filter.
   # * <tt>:when_filtered</tt> - when the table is the result of filtering


### PR DESCRIPTION
This should fix our CSV export issues. The encoding was selected for excel compatibility, but in theory the issue this config setting is trying to fix should really only impact older versions of excel, and TWW is mostly using google sheets anyway. We can obviously change this back at some point if needed, but unless TWW reports problems to us, I expect this is the best solution to these issues.