### PR TITLE
disable and hide fields

### DIFF
--- a/app/views/admin/documentations/_form.html.slim
+++ b/app/views/admin/documentations/_form.html.slim
@@ -2,10 +2,10 @@
 
   = f.error_notification
 
-  = f.input :html_identifier, value: params[:html_identifier]
+  = f.input :html_identifier, value: params[:html_identifier], disabled: true
 
-  = f.input :calling_controller
-  = f.input :calling_action
+  = f.input :calling_controller, as: :hidden
+  = f.input :calling_action, as: :hidden
 
   = f.input :previous_url, as: :hidden
 


### PR DESCRIPTION
I disabled the HTML Identifier field and hid the calling action and calling controller fields

I did this so the user is able to differentiate between different documentations
When testing, it felt awkward that all the forms just had text areas saying to fill in page title, page content and summary content